### PR TITLE
Improving config overrides

### DIFF
--- a/functions/drupal/drupal-check-features
+++ b/functions/drupal/drupal-check-features
@@ -33,13 +33,13 @@ drupal_check_features() {
     hasfeatures=0
     return $hasfeatures;
   fi
-  echo -e "Checking that features are not overridden on ${multidev}."
+  echo -e "Checking if features are overridden on ${multidev}."
   local overridden=`terminus drush ${sitename}.${multidev} -- features-list --status=enabled --fields=feature,state 2>/dev/null | grep 'Needs review\|Overridden'`
   if [ "$overridden" != "" ]; then
     echo -e "$overridden"
     echo -e "There are features overrides.  These should be probably be cleaned up first."
     if [ "$multidev" == 'test' ]; then
-      read -p "${UNDERLINE}[exit] so that you can clean up manually. [continue] on to the next step without making changes.${NOUNDERLINE} " continue;
+      read -p "${UNDERLINE}Cannot export config on the test environment. [exit] so that you can clean up manually. [continue] on to the next step without making changes.${NOUNDERLINE} " continue;
     else
       read -p "${UNDERLINE}[exit] so that you can clean up manually. [auto] clean-up automatically (save all overrides to code, warning: only choose this if this environment has a fresh copy of the live database, or if these overrides are your own changes that you know need to get back into code). [continue] on to the next step without making changes.${NOUNDERLINE} " continue;
     fi

--- a/functions/drupal8/drupal8-config-export
+++ b/functions/drupal8/drupal8-config-export
@@ -26,6 +26,7 @@ drupal_config_export() {
   local sitename=$1
   local multidev=$2
   local checkforoverrides=$3
+  local continue
   local isoverridden=0
   local shouldexport=0
 

--- a/functions/drupal8/drupal8-config-export
+++ b/functions/drupal8/drupal8-config-export
@@ -26,7 +26,6 @@ drupal_config_export() {
   local sitename=$1
   local multidev=$2
   local checkforoverrides=$3
-  local continue
   local isoverridden=0
   local shouldexport=0
 
@@ -38,34 +37,22 @@ drupal_config_export() {
   fi
 
   if [ "$isoverridden" == 1 ] || [ "$checkforoverrides" == 0 ]; then
+    echo -e "There are configuration overrides.  These should be probably be cleaned up first."
     if [ "$multidev" == "test" ]; then
-      read -p "${UNDERLINE}Cannot export config on the test environment.  Do you want to exit so that you can clean this up manually (or ignore and continue to the next step)? (${BOLD}Y${NOBOLD}/N) ${NOUNDERLINE}"  exit
-      case $exit in
-        [Nn]) ;;
-        *)
-          cleanup_on_error $sitename $multidev "Cannot export configuration on test." 12
-          ;;
-      esac
-    elif [ "$multidev" == "dev" ]; then
-      read -p "${UNDERLINE}Should these overrides be exported to code before continuing (Typically you shouldn't because the dev environment often has an out-of-date databse)? (Y/${BOLD}N${NOBOLD}) ${NOUNDERLINE}" export
-      case $export in
-        [Yy])
-          shouldexport=1
-          ;;
-        *) ;;
-      esac
+      read -p "${UNDERLINE}Cannot export config on the test environment. [exit] so that you can clean up manually. [continue] on to the next step without making changes.${NOUNDERLINE} " continue;
     else
-      # @todo Need some more help text and options here, similar to what we do for Features in D7.
-      read -p "${UNDERLINE}Should these overrides be exported to code before continuing? (${BOLD}Y${NOBOLD}/N) ${NOUNDERLINE}" export
-      case $export in
-        [Nn]) ;;
-        *)
-          shouldexport=1
-          ;;
-      esac
+      read -p "${UNDERLINE}[exit] so that you can clean up manually. [auto] clean-up automatically (save all overrides to code, warning: only choose this if this environment has a fresh copy of the live database, or if these overrides are your own changes that you know need to get back into code). [continue] on to the next step without making changes.${NOUNDERLINE} " continue;
     fi
-
-    if [ "$shouldexport" == 1 ]; then
+    # We can't assume that an auto cleanup should be default.  If we come across
+    # overrides on dev it might be because the DB hasn't been refreshed in a
+    # while.
+    if [ "$continue" == "" ]; then
+      continue="exit"
+    fi
+    if [ "$continue" == "exit" ]; then
+      echo -e "You can clean up the config on this branch.  Then you can re-run this script to continue."
+      exit 0
+    elif [ "$continue" == "auto" ]; then
       connection_mode "$sitename" "$multidev" 'sftp'
       echo -e "Exporting config:"
       terminus drush ${sitename}.${multidev} -- config-export -y

--- a/functions/drupal8/drupal8-config-show-overridden
+++ b/functions/drupal8/drupal8-config-show-overridden
@@ -34,6 +34,7 @@ drupal_config_show_overridden() {
     echo -e "  $link"
     exit 1
   else
+    # @todo Do we need this line here? User has already been informed we are checking for overrides when this is called from drupal8-check-config-management
     echo -e "Checking for overridden config on ${env}."
     local overridden=`terminus drush ${sitename}.${env} -- config-import -n --preview=list  2>/dev/null | fgrep -v "There are no changes to import" | fgrep -v 'Import the listed configuration changes?'`
     if [ "$overridden" != "" ]; then

--- a/functions/drupal8/drupal8-config-show-overridden
+++ b/functions/drupal8/drupal8-config-show-overridden
@@ -34,7 +34,8 @@ drupal_config_show_overridden() {
     echo -e "  $link"
     exit 1
   else
-    # @todo Do we need this line here? User has already been informed we are checking for overrides when this is called from drupal8-check-config-management
+    # This is similar to the message already given in drupal8-check-config-management, 
+    # but we also show something here for easier debugging when things go awry.
     echo -e "Checking for overridden config on ${env}."
     local overridden=`terminus drush ${sitename}.${env} -- config-import -n --no --preview=list  2>/dev/null | fgrep -v "There are no changes to import" | fgrep -v 'Import the listed configuration changes?'`
     if [ "$overridden" != "" ]; then

--- a/functions/drupal8/drupal8-config-show-overridden
+++ b/functions/drupal8/drupal8-config-show-overridden
@@ -36,7 +36,7 @@ drupal_config_show_overridden() {
   else
     # @todo Do we need this line here? User has already been informed we are checking for overrides when this is called from drupal8-check-config-management
     echo -e "Checking for overridden config on ${env}."
-    local overridden=`terminus drush ${sitename}.${env} -- config-import -n --preview=list  2>/dev/null | fgrep -v "There are no changes to import" | fgrep -v 'Import the listed configuration changes?'`
+    local overridden=`terminus drush ${sitename}.${env} -- config-import -n --no --preview=list  2>/dev/null | fgrep -v "There are no changes to import" | fgrep -v 'Import the listed configuration changes?'`
     if [ "$overridden" != "" ]; then
       echo -e "$overridden"
       isoverridden=1

--- a/functions/pantheon-env-merge
+++ b/functions/pantheon-env-merge
@@ -101,12 +101,12 @@ env_merge() {
       fi
       ;;
     drupal8)
-      drupal_config_import "$sitename" "$env_dest"
       echo -e "Checking for database updates."
       terminus drush ${sitename}.${env_dest} -- updatedb -y 2>&1 | fgrep -v 'This environment is in read-only Git mode' | fgrep -v '[Exit: 0]'
       if [ $? != 0 ]; then
         error_no_cleanup "Error running drush updatedb." 14
       fi
+      drupal_config_import "$sitename" "$env_dest"
       ;;
     *)
       # @todo WP.


### PR DESCRIPTION
Changes here:

- create more parity between D7 and D8 process - use similar language and offer similar options
- for D8, do not import config after checking for overrides and exiting - use explicit --no flag to prevent this
- for D8, import config after running DB updates rather than before - there is some debate, but this seems to be the recommended practice; it was necessary for the 8.8 -> 8.9/9 upgrades