### PR TITLE
more filters for pantheon-module-report

### DIFF
--- a/functions/drupal/drupal-get-drush-version
+++ b/functions/drupal/drupal-get-drush-version
@@ -32,7 +32,7 @@ drupal_get_drush_version() {
   local version=`terminus drush ${sitename}.${multidev} -- --version --pipe  2>/dev/null`
 
   if [ "$version" == "" ]; then
-    echo "Cannot determine the version of Drush.  Proceeding assuming that everything is going to work out fine."
+    echo "$sitename: Cannot determine the version of Drush.  Proceeding assuming that everything is going to work out fine."
     eval "$4='0'"
     return;
   fi

--- a/pantheon-module-report
+++ b/pantheon-module-report
@@ -12,12 +12,15 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 
 MODULE=$1
 if [ "$MODULE" == "" ]; then
-  read -p "${UNDERLINE}What module do you want a report about? Enter its machine name.  e.g. print  To test Drupal Core, type system:${NOUNDERLINE} " MODULE
+  read -p "${UNDERLINE}What module do you want a report about? Enter its machine name.  e.g. print  To test Drupal Core, type system:${NOUNDERLINE} [system] " MODULE
+  if [ "$MODULE" == "" ]; then
+    MODULE='system'
+  fi
 fi
 
 VERBOSITY=$2
 if [ "$VERBOSITY" == "" ]; then
-  read -p "${UNDERLINE}Also list sites that don't have the module? (Y/${BOLD}N${NOBOLD}) ${NOUNDERLINE}"  VERBOSITY
+  read -p "${UNDERLINE}Also list sites that don't have the module? (Y/${BOLD}N${NOBOLD})${NOUNDERLINE} [N] "  VERBOSITY
   case $VERBOSITY in
     [Yy]) ;;
     *)
@@ -26,7 +29,27 @@ if [ "$VERBOSITY" == "" ]; then
   esac
 fi
 
-sites=$(terminus site:list --format=list --field=name --filter="frozen!=1" | sort)
+ORG=$3
+if [ "$ORG" == "" ]; then
+  read -p "${UNDERLINE}Do you want to check sites in a specific Pantheon organization? Enter the organization name, e.g. four-kitchens:${NOUNDERLINE} [ ] " ORG
+fi
+
+TAG=$4
+if [ "$TAG" == "" ] && [ "$ORG" != "" ]; then
+  read -p "${UNDERLINE}Do you want to check sites with a certain tag? Enter the tag name, e.g. cc-d7, cc-d9, cc-drupal:${NOUNDERLINE} [ ] " TAG
+fi
+
+if [ "$ORG" != "" ]; then
+  if [ "$TAG" != "" ]; then
+    sites=$(terminus org:site:list ${ORG} --format=list --field=name --filter="frozen!=1" --tag=${TAG} | sort)
+  else
+    sites=$(terminus org:site:list ${ORG} --format=list --field=name --filter="frozen!=1" | sort)
+  fi
+else
+  sites=$(terminus site:list --format=list --field=name --filter="frozen!=1" | sort)
+fi
+
+# for debugging purposes, you may want to set 'sites' to a specific site or string of sites
 #sites=('bric')
 
 for site in $sites; do

--- a/pantheon-module-report
+++ b/pantheon-module-report
@@ -11,18 +11,20 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 #set -x
 
 MODULE=$1
-if [ "$MODULE" == "" ]; then
+if [[ -z "$MODULE" ]]; then
   read -p "${UNDERLINE}What module do you want a report about? Enter its machine name.  e.g. print  To test Drupal Core, type system:${NOUNDERLINE} [system] " MODULE
-  if [ "$MODULE" == "" ]; then
+  if [[ -z "$MODULE" ]]; then
     MODULE='system'
   fi
 fi
 
 VERBOSITY=$2
-if [ "$VERBOSITY" == "" ]; then
+if [[ -z "$VERBOSITY" ]]; then
   read -p "${UNDERLINE}Also list sites that don't have the module? (Y/${BOLD}N${NOBOLD})${NOUNDERLINE} [N] "  VERBOSITY
   case $VERBOSITY in
-    [Yy]) ;;
+    [Yy])
+      VERBOSITY=y
+      ;;
     *)
       VERBOSITY=n
       ;;
@@ -30,17 +32,17 @@ if [ "$VERBOSITY" == "" ]; then
 fi
 
 ORG=$3
-if [ "$ORG" == "" ]; then
+if [[ -z "$ORG" ]]; then
   read -p "${UNDERLINE}Do you want to check sites in a specific Pantheon organization? Enter the organization name, e.g. four-kitchens:${NOUNDERLINE} [ ] " ORG
 fi
 
 TAG=$4
-if [ "$TAG" == "" ] && [ "$ORG" != "" ]; then
+if [[ -z "$TAG" && -n "$ORG" ]]; then
   read -p "${UNDERLINE}Do you want to check sites with a certain tag? Enter the tag name, e.g. cc-d7, cc-d9, cc-drupal:${NOUNDERLINE} [ ] " TAG
 fi
 
-if [ "$ORG" != "" ]; then
-  if [ "$TAG" != "" ]; then
+if [[ -n "$ORG" ]]; then
+  if [[ -n "$TAG" ]]; then
     sites=$(terminus org:site:list ${ORG} --format=list --field=name --filter="frozen!=1" --tag=${TAG} | sort)
   else
     sites=$(terminus org:site:list ${ORG} --format=list --field=name --filter="frozen!=1" | sort)


### PR DESCRIPTION
Add ability to filter sites by organization and tag when running pantheon-module-report. This will make our security update checks more efficient, because we can target specific groups of sites that are affected by the release. Developers can also avoid checking all sites they have access to in Pantheon.

I've added tags in the four-kitchens org:

- cc-active : all active continuous care sites
- cc-drupal: all cc drupal sites
- cc-d7: all cc drupal 7 sites
- cc-d9: all cc drupal 9 sites
- cc-wp: all cc wordpress sites

Tagging system can be expanded as needed to accommodate ci/support and other groups of sites hosted on Pantheon.