### PR TITLE
fix: some filesystems are case-sensitive, make get-framework work

### DIFF
--- a/pantheon-module-report
+++ b/pantheon-module-report
@@ -5,7 +5,7 @@
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 . "$DIR/functions/pantheon-script-colours"
-. "$DIR/functions/pantheon-get-FRAMEWORK"
+. "$DIR/functions/pantheon-get-framework"
 . "$DIR/functions/drupal/drupal-get-drush-version"
 
 #set -x


### PR DESCRIPTION
Was getting the error:
```
./pantheon-module-report: line 8: ./functions/pantheon-get-FRAMEWORK: No such file or directory
```

Pretty self explanatory... I'm on a linux machine where the file system is case sensitive by default. Some Macs would be affected by this too.