### PR TITLE
fix(pr12): Stanford H-S cannot run drush pm-list in live environment.

### DIFF
--- a/pantheon-module-report
+++ b/pantheon-module-report
@@ -77,7 +77,7 @@ for site in $sites; do
         fi
 
         modulestatus=$(echo "$drushoutput" | fgrep -i 'enabled')
-        trynext=$(echo "$drushoutput" | grep 'needs a higher bootstrap level\|command terminated abnormally')
+        trynext=$(echo "$drushoutput" | grep 'needs a higher bootstrap level\|command terminated abnormally\|option does not exist')
         if [ -n "$trynext" ]; then
           if [ "$environment" == 'dev' ]; then
             echo "$site: Could not run drush commands against the live or dev environments."


### PR DESCRIPTION
There's something odd with the Stanford site.  It'll probably be really tricky to find the root problem, but this code is a pretty simple workaround.

See how the same command on different environments produces different results:

on live:
```
➜ terminus drush stanford-hs.live -- pm-list --fields=name,status,version --format=string --filter="name=big_pipe"


  The "--filter" option does not exist.


pm:list [--format [FORMAT]] [--type [TYPE]] [--status [STATUS]] [--package PACKAGE] [--core] [--no-core] [--fields FIELDS] [--field FIELD] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--notify] [--druplicon] [--xh-link XH-LINK] [--] <command>

 [notice] Command: stanford-hs.live -- drush pm-list [Exit: 1]
 [error]
```

on dev:
```
➜ terminus drush stanford-hs.dev -- pm-list --fields=name,status,version --format=string --filter="name=big_pipe"
 [warning] This environment is in read-only Git mode. If you want to make changes to the codebase of this site (e.g. updating modules or plugins), you will need to toggle into read/write SFTP mode first.
big_pipe	Enabled	9.3.22
 [notice] Command: stanford-hs.dev -- drush pm-list [Exit: 0]
```

But yes it _should_ work:

```
➜ terminus drush stanford-hs.live -- pm-list --help
...
 --filter[=FILTER] Filter output based on provided expression
...
```

We already have code to handle different drush versions (that handles the lack of `--filter` on Drush <= 8), and code to cycle through environments if something is broken in the live environment.  So I just added a check for this to the latter.

The same problem was also happening on rutgers-spaa 