### PR TITLE
Check if mysql is installed

### DIFF
--- a/pantheon-db-cli
+++ b/pantheon-db-cli
@@ -2,7 +2,7 @@
 # pantheon-db-cli
 # Get a MySQL commandline on a Pantheon server that requires an SSH tunnel.
 
-# check if command exists and fail otherwise
+# check if mysql is installed and fail otherwise
 command -v mysql >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     echo "mysql is not installed."

--- a/pantheon-db-cli
+++ b/pantheon-db-cli
@@ -2,6 +2,13 @@
 # pantheon-db-cli
 # Get a MySQL commandline on a Pantheon server that requires an SSH tunnel.
 
+# check if command exists and fail otherwise
+command -v mysql >/dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    echo "mysql is not installed."
+      exit 1
+  fi
+
 if [[ $# -lt 2 ]] ; then
 >&2  echo -e 'Usage:'
 >&2  echo -e "  $(basename $0) [site] [environment]"

--- a/pantheon-db-cli
+++ b/pantheon-db-cli
@@ -29,6 +29,10 @@ mysql_username=`echo -e "$connection_info" | grep mysql_username | awk '{print $
 mysql_password=`echo -e "$connection_info" | grep mysql_password | awk '{print $3}'`
 mysql_database=`echo -e "$connection_info" | grep mysql_database | awk '{print $3}'`
 
+if [ "$mysql_database" == '' ]; then
+    mysql_database="pantheon"
+fi
+
 >&2 echo -e "--Now waking up the server.--"
 terminus env:wake $1.$2
 

--- a/pantheon-db-cli
+++ b/pantheon-db-cli
@@ -2,12 +2,8 @@
 # pantheon-db-cli
 # Get a MySQL commandline on a Pantheon server that requires an SSH tunnel.
 
-# check if mysql is installed and fail otherwise
-command -v mysql >/dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    echo "mysql is not installed."
-      exit 1
-  fi
+# Check if mysql is installed locally.
+command -v mysql >/dev/null 2>&1 || { echo >&2 "FAILURE. MySQL is required. Please install mysql locally and run the command again."; exit 1; }
 
 if [[ $# -lt 2 ]] ; then
 >&2  echo -e 'Usage:'

--- a/pantheon-db-dump
+++ b/pantheon-db-dump
@@ -3,7 +3,7 @@
 # Dump a DB from a Pantheon environment.
 
 # Check if mysql is installed locally.
-command -v mysql >/dev/null 2>&1 || { echo >&2 "FAILURE. MySQL is required. Please install mysql locally and run the command again."; exit 1; }
+command -v mysqldump >/dev/null 2>&1 || { echo >&2 "FAILURE. MySQL is required. Please install mysql locally and run the command again."; exit 1; }
 
 if [[ $# -lt 2 ]] ; then
 >&2  echo -e 'Usage:'

--- a/pantheon-db-dump
+++ b/pantheon-db-dump
@@ -30,6 +30,10 @@ mysql_username=`echo -e "$connection_info" | grep mysql_username | awk '{print $
 mysql_password=`echo -e "$connection_info" | grep mysql_password | awk '{print $3}'`
 mysql_database=`echo -e "$connection_info" | grep mysql_database | awk '{print $3}'`
 
+if [ "$mysql_database" == '' ]; then
+    mysql_database="pantheon"
+fi
+
 # First "Wake up" the server.
 >&2 echo -e "--Now waking up the server.--"
 terminus env:wake $1.$2
@@ -48,7 +52,7 @@ if command -v pv >/dev/null 2>&1; then
 fi
 
 #Transfer the Database.
->&2 echo -e "--Now transfering the database.--"
+>&2 echo -e "--Now transferring the database.--"
 mysqldump --no-autocommit --single-transaction -B --column-statistics=0 --opt --quote-names --user=$mysql_username --host=127.0.0.1 --port=$mysql_port --password=$mysql_password $mysql_database | $PV
 
 # Kill the SSH session.

--- a/pantheon-db-dump
+++ b/pantheon-db-dump
@@ -2,6 +2,9 @@
 # pantheon-db-dump
 # Dump a DB from a Pantheon environment.
 
+# Check if mysql is installed locally.
+command -v mysql >/dev/null 2>&1 || { echo >&2 "FAILURE. MySQL is required. Please install mysql locally and run the command again."; exit 1; }
+
 if [[ $# -lt 2 ]] ; then
 >&2  echo -e 'Usage:'
 >&2  echo -e "  $(basename $0) [site] [environment] | drush sql-cli"


### PR DESCRIPTION
This will check if mysql is installed and exit if not when the `pantheon-db-cli` command is executed. I didn't have to have mysql enabled/running for the command to continue to work but please test that again.

- [ ] run `pantheon-db-cli eam-d8 live` on environment with mysql installed.
- [ ] run `pantheon-db-cli eam-d8 live` on environment with msyql installed and disabled.
- [ ] run `pantheon-db-cli eam-d8 live` on environment with msyql uninstalled/removed and notice the message informing the user that mysql is not installed locally.